### PR TITLE
feat: Add configuration option to skip video downloads

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/AbstractRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/AbstractRipper.java
@@ -790,6 +790,13 @@ public abstract class AbstractRipper
     }
 
     protected boolean shouldIgnoreURL(URL url) {
+        // Check if videos should be skipped
+        if (Utils.getConfigBoolean("download.skip_videos", false) && isVideoURL(url)) {
+            logger.info("[!] Skipping video file: " + url);
+            return true;
+        }
+
+        // Check for ignored extensions
         final String[] ignoredExtensions = Utils.getConfigStringArray("download.ignore_extensions");
         if (ignoredExtensions == null || ignoredExtensions.length == 0)
             return false; // nothing ignored
@@ -799,6 +806,22 @@ public abstract class AbstractRipper
         String extension = pathElements[pathElements.length - 1];
         for (String ignoredExtension : ignoredExtensions) {
             if (ignoredExtension.equalsIgnoreCase(extension)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Checks if a URL points to a video file based on its extension
+     * @param url URL to check
+     * @return true if the URL points to a video file
+     */
+    protected boolean isVideoURL(URL url) {
+        String[] videoExtensions = {"mp4", "webm", "m4v", "avi", "mov", "flv", "wmv", "mpg", "mpeg"};
+        String path = url.getPath().toLowerCase();
+        for (String ext : videoExtensions) {
+            if (path.endsWith("." + ext)) {
                 return true;
             }
         }

--- a/src/main/resources/rip.properties
+++ b/src/main/resources/rip.properties
@@ -20,6 +20,9 @@ download.max_size = 104857600
 # Any URLs ending with one of these comma-separated values will be skipped
 #download.ignore_extensions = mp4,gif,m4v,webm,html
 
+# Skip downloading video files on mixed content sites
+download.skip_videos = false
+
 # Don't retry on 404 errors
 error.skip404 = true
 

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/VideoSkipTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/VideoSkipTest.java
@@ -1,0 +1,114 @@
+package com.rarchives.ripme.tst.ripper.rippers;
+
+import java.net.URL;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.rarchives.ripme.ripper.AbstractRipper;
+import com.rarchives.ripme.utils.Utils;
+
+public class VideoSkipTest {
+
+    @Test
+    public void testVideoDetection() throws Exception {
+        TestRipper ripper = new TestRipper(new URL("http://example.com"));
+        
+        // Test video URLs
+        assertTrue(ripper.testIsVideoURL(new URL("http://example.com/video.mp4")));
+        assertTrue(ripper.testIsVideoURL(new URL("http://example.com/video.webm")));
+        assertTrue(ripper.testIsVideoURL(new URL("http://example.com/video.m4v")));
+        assertTrue(ripper.testIsVideoURL(new URL("http://example.com/video.avi")));
+        
+        // Test non-video URLs
+        assertFalse(ripper.testIsVideoURL(new URL("http://example.com/image.jpg")));
+        assertFalse(ripper.testIsVideoURL(new URL("http://example.com/image.png")));
+        assertFalse(ripper.testIsVideoURL(new URL("http://example.com/image.gif")));
+    }
+
+    @Test
+    public void testVideoSkipping() throws Exception {
+        TestRipper ripper = new TestRipper(new URL("http://example.com"));
+        
+        // Enable video skipping
+        Utils.setConfigBoolean("download.skip_videos", true);
+        
+        // Should skip video URLs
+        assertTrue(ripper.testShouldIgnoreURL(new URL("http://example.com/video.mp4")));
+        assertTrue(ripper.testShouldIgnoreURL(new URL("http://example.com/video.webm")));
+        
+        // Should not skip non-video URLs
+        assertFalse(ripper.testShouldIgnoreURL(new URL("http://example.com/image.jpg")));
+        assertFalse(ripper.testShouldIgnoreURL(new URL("http://example.com/image.png")));
+        
+        // Disable video skipping
+        Utils.setConfigBoolean("download.skip_videos", false);
+        
+        // Should not skip any URLs when disabled
+        assertFalse(ripper.testShouldIgnoreURL(new URL("http://example.com/video.mp4")));
+        assertFalse(ripper.testShouldIgnoreURL(new URL("http://example.com/image.jpg")));
+    }
+
+    // Test ripper class that exposes protected methods for testing
+    private static class TestRipper extends AbstractRipper {
+        public TestRipper(URL url) throws Exception {
+            super(url);
+        }
+
+        public boolean testIsVideoURL(URL url) {
+            return isVideoURL(url);
+        }
+
+        public boolean testShouldIgnoreURL(URL url) {
+            return shouldIgnoreURL(url);
+        }
+
+        @Override
+        public void rip() {}
+
+        @Override
+        public String getHost() {
+            return "example.com";
+        }
+
+        @Override
+        public String getGID(URL url) {
+            return "test";
+        }
+
+        @Override
+        public void setWorkingDir(URL url) {}
+
+        @Override
+        public String getAlbumTitle(URL url) {
+            return "test";
+        }
+
+        @Override
+        public boolean addURLToDownload(URL url, Path saveAs) {
+            return false;
+        }
+
+        @Override
+        public void downloadCompleted(URL url, Path saveAs) {}
+
+        @Override
+        public void downloadErrored(URL url, String reason) {}
+
+        @Override
+        public void downloadExists(URL url, Path file) {}
+
+        @Override
+        public int getCompletionPercentage() {
+            return 0;
+        }
+
+        @Override
+        public String getStatusText() {
+            return "";
+        }
+    }
+}


### PR DESCRIPTION
## Description
Implements a new configuration option that allows users to skip video downloads when ripping from mixed content sites. This helps users who only want to download images and other non-video content.

## Changes
- Added `download.skip_videos` configuration option (default: false)
- Added video file detection based on common video extensions
- Added unit tests to verify video detection and skipping behavior

## Testing
Added comprehensive tests in `VideoSkipTest.java` that verify:
- Video file detection for common formats (mp4, webm, m4v, etc.)
- Proper handling of the skip_videos configuration option
- Non-video files are not affected

## Related Issues
Fixes #1

---
*This PR was created by an AI assistant*